### PR TITLE
data/bobcat.yaml, rerun with Bobcat v0.9.7 (r351)

### DIFF
--- a/data/bobcat.yaml
+++ b/data/bobcat.yaml
@@ -1,7 +1,7 @@
-datetime: 2025-11-02 14:06:36 UTC
-height: 45
-python_version: 3.13.6
-seconds_elapsed: 70.27704179298598
+datetime: 2025-11-06 05:20:07 UTC
+height: 24
+python_version: 3.13.7
+seconds_elapsed: 103.50504856195766
 session_arguments:
   limit_codepoints: 5000
   limit_errors: 1000
@@ -9,14 +9,15 @@ session_arguments:
   quick: false
   stream: stderr
 software_name: Bobcat
-software_version: 0.9.7 (r348)
+software_version: 0.9.7 (r351)
 system: Linux
 terminal_results:
-  cell_height: 23
-  cell_width: 10
+  cell_height: 18
+  cell_width: 8
   device_attributes:
     extensions:
     - 1
+    - 4
     - 6
     - 8
     - 9
@@ -25,8 +26,11 @@ terminal_results:
     - 21
     - 22
     - 28
+    - 52
+    - 444
+    - 1337
     service_class: 64
-  height: 45
+  height: 24
   modes:
     1:
       changeable: true
@@ -1304,19 +1308,19 @@ terminal_results:
       value: 0
       value_description: NOT_RECOGNIZED
   number_of_colors: 16777216
-  pixels_height: 1035
-  pixels_width: 1700
+  pixels_height: 432
+  pixels_width: 640
   screen_ratio: '16:10'
   screen_ratio_name: WSXGA
-  sixel: false
+  sixel: true
   software_name: Bobcat
-  software_version: 0.9.7 (r348)
+  software_version: 0.9.7 (r351)
   ttype: xterm-256color
-  width: 170
+  width: 80
 test_results:
   emoji_vs15_results:
     9.0.0:
-      codepoints_per_second: 4974.045711020775
+      codepoints_per_second: 2357.2449143107106
       failed_codepoints:
       - measured_by_terminal: 2
         measured_by_wcwidth: 1
@@ -1795,10 +1799,10 @@ test_results:
       n_errors: 158
       n_total: 158
       pct_success: 0.0
-      seconds_elapsed: 0.03176488701137714
+      seconds_elapsed: 0.0670274009462446
   emoji_vs16_results:
     9.0.0:
-      codepoints_per_second: 4882.236893717852
+      codepoints_per_second: 2052.5875046046763
       failed_codepoints:
       - measured_by_terminal: 1
         measured_by_wcwidth: 2
@@ -1842,681 +1846,84 @@ test_results:
       - measured_by_terminal: 1
         measured_by_wcwidth: 2
         wchar: \xae\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u203c\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2049\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2122\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2139\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2194\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2195\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2196\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2197\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2198\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2199\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u21a9\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u21aa\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2328\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u23cf\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u23ed\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u23ee\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u23ef\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u23f1\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u23f2\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u23f8\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u23f9\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u23fa\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u24c2\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u25aa\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u25ab\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u25b6\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u25c0\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u25fb\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u25fc\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2600\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2601\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2602\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2603\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2604\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u260e\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2611\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2618\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u261d\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2620\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2622\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2623\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2626\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u262a\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u262e\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u262f\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2638\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2639\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u263a\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2640\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2642\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u265f\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2660\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2663\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2665\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2666\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2668\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u267b\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u267e\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2692\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2694\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2695\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2696\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2697\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2699\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u269b\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u269c\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26a0\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26a7\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26b0\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26b1\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26c8\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26cf\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26d1\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26d3\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26e9\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26f0\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26f1\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26f4\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26f7\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26f8\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u26f9\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2702\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2708\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2709\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u270c\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u270d\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u270f\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2712\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2714\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2716\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u271d\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2721\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2733\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2734\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2744\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2747\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2763\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2764\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u27a1\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2934\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2935\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2b05\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2b06\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \u2b07\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f170\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f171\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f17e\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f17f\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f321\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f324\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f325\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f326\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f327\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f328\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f329\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f32a\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f32b\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f32c\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f336\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f37d\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f396\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f397\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f399\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f39a\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f39b\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f39e\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f39f\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3cb\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3cc\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3cd\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3ce\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3d4\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3d5\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3d6\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3d7\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3d8\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3d9\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3da\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3db\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3dc\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3dd\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3de\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3df\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3f3\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3f5\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f3f7\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f43f\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f441\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f4fd\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f549\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f54a\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f56f\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f570\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f573\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f574\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f575\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f576\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f577\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f578\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f579\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f587\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f58a\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f58b\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f58c\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f58d\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f590\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5a5\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5a8\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5b1\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5b2\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5bc\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5c2\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5c3\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5c4\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5d1\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5d2\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5d3\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5dc\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5dd\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5de\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5e1\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5e3\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5e8\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5ef\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5f3\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f5fa\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6cb\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6cd\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6ce\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6cf\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6e0\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6e1\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6e2\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6e3\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6e4\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6e5\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6e9\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6f0\ufe0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6f3\ufe0f
-      n_errors: 213
+      n_errors: 14
       n_total: 213
-      pct_success: 0.0
-      seconds_elapsed: 0.043627542996546254
+      pct_success: 93.42723004694837
+      seconds_elapsed: 0.1037714589620009
   emoji_zwj_results:
     '11.0':
-      codepoints_per_second: 4382.395064482778
+      codepoints_per_second: 2608.760194224002
       failed_codepoints:
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9b8\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9b8\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b8\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b8\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b8\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b8\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b8\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b8\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b8\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b8\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b8\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b8\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9b9\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9b9\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b9\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b9\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b9\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b9\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b9\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b9\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b9\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b9\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b9\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9b9\U0001f3ff\u200d\u2642\ufe0f
       - measured_by_terminal: 4
@@ -2663,15 +2070,15 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\U0001f9b3
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f3f4\u200d\u2620\ufe0f
       n_errors: 73
       n_total: 73
       pct_success: 0.0
-      seconds_elapsed: 0.01665755800786428
+      seconds_elapsed: 0.027982641011476517
     '12.0':
-      codepoints_per_second: 4712.833191429762
+      codepoints_per_second: 2474.3669974313666
       failed_codepoints:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
@@ -2898,112 +2305,112 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\U0001f9bd
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9cd\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9cd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cd\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cd\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cd\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cd\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cd\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cd\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cd\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cd\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cd\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cd\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9cf\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9cf\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cf\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cf\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cf\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cf\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cf\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cf\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cf\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cf\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cf\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9cf\U0001f3ff\u200d\u2642\ufe0f
       - measured_by_terminal: 4
@@ -3012,9 +2419,9 @@ test_results:
       n_errors: 112
       n_total: 112
       pct_success: 0.0
-      seconds_elapsed: 0.02376489798189141
+      seconds_elapsed: 0.04526410193648189
     '12.1':
-      codepoints_per_second: 4460.866319645438
+      codepoints_per_second: 2514.1762592160135
       failed_codepoints:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
@@ -3097,13 +2504,13 @@ test_results:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fe\u200d\U0001f91d\u200d\U0001f9d1\U0001f3ff
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\u200d\u2695\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\u200d\u2696\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\u200d\u2708\ufe0f
       - measured_by_terminal: 4
@@ -3154,13 +2561,13 @@ test_results:
       - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\u200d\U0001f9bd
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -3211,13 +2618,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\U0001f9bd
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fc\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fc\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fc\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -3268,13 +2675,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fc\u200d\U0001f9bd
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -3325,13 +2732,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\U0001f9bd
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fe\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fe\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fe\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -3382,13 +2789,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fe\u200d\U0001f9bd
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -3514,9 +2921,9 @@ test_results:
       n_errors: 165
       n_total: 165
       pct_success: 0.0
-      seconds_elapsed: 0.036988331004977226
+      seconds_elapsed: 0.06562785699497908
     '13.0':
-      codepoints_per_second: 4476.3472404678605
+      codepoints_per_second: 2116.4428697746107
       failed_codepoints:
       - measured_by_terminal: 4
         measured_by_wcwidth: 2
@@ -3590,329 +2997,332 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\U0001f384
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f470\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f470\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f470\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f470\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f470\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f470\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f470\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f470\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f470\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f470\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f470\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f470\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f935\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f935\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f935\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f935\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f935\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f935\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f935\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f935\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f935\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f935\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f935\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f935\U0001f3ff\u200d\u2642\ufe0f
       - measured_by_terminal: 4
         measured_by_wcwidth: 2
+        wchar: \U0001f3f3\ufe0f\u200d\u26a7\ufe0f
+      - measured_by_terminal: 4
+        measured_by_wcwidth: 2
         wchar: \U0001f408\u200d\u2b1b
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f43b\u200d\u2744\ufe0f
-      n_errors: 50
+      n_errors: 51
       n_total: 51
-      pct_success: 1.9607843137254901
-      seconds_elapsed: 0.011393218010198325
+      pct_success: 0.0
+      seconds_elapsed: 0.024097035988233984
     '13.1':
-      codepoints_per_second: 4725.282599683555
+      codepoints_per_second: 2593.6734096601435
       failed_codepoints:
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fe
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fc
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fc
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fe
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fe
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fc
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fe
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f469\U0001f3fb
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f469\U0001f3fb
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f469\U0001f3fd
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f469\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\u2764\ufe0f\u200d\U0001f469\U0001f3fc
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fc
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f469\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f469\U0001f3fd
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f469\U0001f3fb
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f469\U0001f3fd
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f469\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fe
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\u2764\ufe0f\u200d\U0001f469\U0001f3fe
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fe
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f469\U0001f3fe
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f469\U0001f3ff
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f469\U0001f3fb
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f469\U0001f3fd
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f469\U0001f3ff
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f9d1\U0001f3ff
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f9d1\U0001f3ff
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f9d1\U0001f3fb
-      - measured_by_terminal: 11
+      - measured_by_terminal: 12
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f9d1\U0001f3fd
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d4\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d4\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d4\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d4\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d4\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d4\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d4\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d4\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d4\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d4\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d4\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d4\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \u2764\ufe0f\u200d\U0001f525
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \u2764\ufe0f\u200d\U0001fa79
       - measured_by_terminal: 4
@@ -3921,15 +3331,15 @@ test_results:
       - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f635\u200d\U0001f4ab
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f636\u200d\U0001f32b\ufe0f
       n_errors: 83
       n_total: 83
       pct_success: 0.0
-      seconds_elapsed: 0.01756508700782433
+      seconds_elapsed: 0.03200094494968653
     '14.0':
-      codepoints_per_second: 4190.658198984577
+      codepoints_per_second: 2789.338460646226
       failed_codepoints:
       - measured_by_terminal: 8
         measured_by_wcwidth: 2
@@ -3994,9 +3404,9 @@ test_results:
       n_errors: 20
       n_total: 20
       pct_success: 0.0
-      seconds_elapsed: 0.004772519983816892
+      seconds_elapsed: 0.00717015890404582
     '15.0':
-      codepoints_per_second: 2023.0833666836495
+      codepoints_per_second: 1457.0292003427014
       failed_codepoints:
       - measured_by_terminal: 4
         measured_by_wcwidth: 2
@@ -4004,9 +3414,9 @@ test_results:
       n_errors: 1
       n_total: 1
       pct_success: 0.0
-      seconds_elapsed: 0.0004942950035911053
+      seconds_elapsed: 0.000686328043229878
     '15.1':
-      codepoints_per_second: 4677.51876349014
+      codepoints_per_second: 2432.530911995209
       failed_codepoints:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
@@ -4020,304 +3430,304 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\u200d\U0001f9d2\u200d\U0001f9d2
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fb\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fe\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3ff\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\u200d\U0001f9bc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\U0001f9bc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\U0001f9bc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\U0001f9bc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\U0001f9bc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\U0001f9bc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\U0001f9bc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\U0001f9bc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fb\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fe\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3ff\u200d\u27a1\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fb\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fe\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3ff\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\u200d\U0001f9bc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\U0001f9bc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fc\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\U0001f9bc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fe\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\U0001f9af\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\U0001f9bc\u200d\u27a1\ufe0f
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\U0001f9bd\u200d\u27a1\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fb\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fb\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fc\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fc\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fd\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fd\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fe\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fe\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3ff\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3ff\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fb\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fb\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fc\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fc\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fd\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fd\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fe\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fe\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3ff\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3ff\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fb\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fb\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fc\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fc\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fd\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fd\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fe\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3fe\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3ff\u200d\u2640\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 6
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f9ce\U0001f3ff\u200d\u2642\ufe0f\u200d\u27a1\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \u26d3\ufe0f\u200d\U0001f4a5
       - measured_by_terminal: 4
@@ -4329,18 +3739,18 @@ test_results:
       - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f426\u200d\U0001f525
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f642\u200d\u2194\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f642\u200d\u2195\ufe0f
       n_errors: 109
       n_total: 109
       pct_success: 0.0
-      seconds_elapsed: 0.02330295302090235
+      seconds_elapsed: 0.044809296960011125
     '17.0':
-      codepoints_per_second: 4396.437154295349
+      codepoints_per_second: 2649.9166949024834
       failed_codepoints:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
@@ -4354,16 +3764,16 @@ test_results:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\U0001f430\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\U0001faef\u200d\U0001f468\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\U0001faef\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\U0001faef\u200d\U0001f468\U0001f3fe
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\U0001faef\u200d\U0001f468\U0001f3ff
       - measured_by_terminal: 10
@@ -4375,16 +3785,16 @@ test_results:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\U0001f430\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\U0001faef\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\U0001faef\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\U0001faef\u200d\U0001f468\U0001f3fe
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\U0001faef\u200d\U0001f468\U0001f3ff
       - measured_by_terminal: 10
@@ -4399,16 +3809,16 @@ test_results:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\U0001f430\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\U0001faef\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\U0001faef\u200d\U0001f468\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\U0001faef\u200d\U0001f468\U0001f3fe
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\U0001faef\u200d\U0001f468\U0001f3ff
       - measured_by_terminal: 10
@@ -4420,16 +3830,16 @@ test_results:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\U0001f430\u200d\U0001f468\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\U0001faef\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\U0001faef\u200d\U0001f468\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\U0001faef\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\U0001faef\u200d\U0001f468\U0001f3ff
       - measured_by_terminal: 10
@@ -4444,16 +3854,16 @@ test_results:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\U0001f430\u200d\U0001f468\U0001f3fe
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\U0001faef\u200d\U0001f468\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\U0001faef\u200d\U0001f468\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\U0001faef\u200d\U0001f468\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\U0001faef\u200d\U0001f468\U0001f3fe
       - measured_by_terminal: 10
@@ -4468,16 +3878,16 @@ test_results:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\U0001f430\u200d\U0001f469\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\U0001faef\u200d\U0001f469\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\U0001faef\u200d\U0001f469\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\U0001faef\u200d\U0001f469\U0001f3fe
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\U0001faef\u200d\U0001f469\U0001f3ff
       - measured_by_terminal: 10
@@ -4486,16 +3896,16 @@ test_results:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\U0001f430\u200d\U0001f469\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\U0001faef\u200d\U0001f469\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\U0001faef\u200d\U0001f469\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\U0001faef\u200d\U0001f469\U0001f3fe
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\U0001faef\u200d\U0001f469\U0001f3ff
       - measured_by_terminal: 10
@@ -4507,16 +3917,16 @@ test_results:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\U0001f430\u200d\U0001f469\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\U0001faef\u200d\U0001f469\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\U0001faef\u200d\U0001f469\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\U0001faef\u200d\U0001f469\U0001f3fe
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\U0001faef\u200d\U0001f469\U0001f3ff
       - measured_by_terminal: 10
@@ -4528,16 +3938,16 @@ test_results:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\U0001f430\u200d\U0001f469\U0001f3ff
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\U0001faef\u200d\U0001f469\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\U0001faef\u200d\U0001f469\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\U0001faef\u200d\U0001f469\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\U0001faef\u200d\U0001f469\U0001f3ff
       - measured_by_terminal: 10
@@ -4552,76 +3962,76 @@ test_results:
       - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\U0001f430\u200d\U0001f469\U0001f3fe
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\U0001faef\u200d\U0001f469\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\U0001faef\u200d\U0001f469\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\U0001faef\u200d\U0001f469\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\U0001faef\u200d\U0001f469\U0001f3fe
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46f\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46f\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46f\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46f\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46f\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46f\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46f\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46f\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46f\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46f\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93c\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93c\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93c\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93c\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93c\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93c\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93c\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93c\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93c\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93c\U0001f3ff\u200d\u2642\ufe0f
       - measured_by_terminal: 4
@@ -4639,16 +4049,16 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\U0001fa70
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\U0001faef\u200d\U0001f9d1\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\U0001faef\u200d\U0001f9d1\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\U0001faef\u200d\U0001f9d1\U0001f3fe
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fb\u200d\U0001faef\u200d\U0001f9d1\U0001f3ff
       - measured_by_terminal: 10
@@ -4657,13 +4067,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fc\u200d\U0001fa70
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fc\u200d\U0001faef\u200d\U0001f9d1\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fc\u200d\U0001faef\u200d\U0001f9d1\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fc\u200d\U0001faef\u200d\U0001f9d1\U0001f3ff
       - measured_by_terminal: 10
@@ -4675,16 +4085,16 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\U0001fa70
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\U0001faef\u200d\U0001f9d1\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\U0001faef\u200d\U0001f9d1\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\U0001faef\u200d\U0001f9d1\U0001f3fe
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fd\u200d\U0001faef\u200d\U0001f9d1\U0001f3ff
       - measured_by_terminal: 10
@@ -4696,13 +4106,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fe\u200d\U0001fa70
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fe\u200d\U0001faef\u200d\U0001f9d1\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fe\u200d\U0001faef\u200d\U0001f9d1\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3fe\u200d\U0001faef\u200d\U0001f9d1\U0001f3ff
       - measured_by_terminal: 10
@@ -4720,29 +4130,29 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\U0001fa70
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\U0001faef\u200d\U0001f9d1\U0001f3fb
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\U0001faef\u200d\U0001f9d1\U0001f3fc
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\U0001faef\u200d\U0001f9d1\U0001f3fd
-      - measured_by_terminal: 9
+      - measured_by_terminal: 10
         measured_by_wcwidth: 2
         wchar: \U0001f9d1\U0001f3ff\u200d\U0001faef\u200d\U0001f9d1\U0001f3fe
       n_errors: 130
       n_total: 130
       pct_success: 0.0
-      seconds_elapsed: 0.02956939800060354
+      seconds_elapsed: 0.04905814595986158
     '2.0':
-      codepoints_per_second: 4565.853715569972
+      codepoints_per_second: 2509.989177186397
       failed_codepoints:
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\u200d\u2764\ufe0f\u200d\U0001f468
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468
       - measured_by_terminal: 6
@@ -4775,16 +4185,16 @@ test_results:
       - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f468\u200d\U0001f469\u200d\U0001f467\u200d\U0001f467
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\u2764\ufe0f\u200d\U0001f468
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\u2764\ufe0f\u200d\U0001f469
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f468
-      - measured_by_terminal: 7
+      - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\u2764\ufe0f\u200d\U0001f48b\u200d\U0001f469
       - measured_by_terminal: 6
@@ -4802,12 +4212,15 @@ test_results:
       - measured_by_terminal: 8
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\U0001f469\u200d\U0001f467\u200d\U0001f467
-      n_errors: 21
+      - measured_by_terminal: 4
+        measured_by_wcwidth: 2
+        wchar: \U0001f441\ufe0f\u200d\U0001f5e8\ufe0f
+      n_errors: 22
       n_total: 22
-      pct_success: 4.545454545454546
-      seconds_elapsed: 0.004818376008188352
+      pct_success: 0.0
+      seconds_elapsed: 0.008764978032559156
     '4.0':
-      codepoints_per_second: 4693.097787692505
+      codepoints_per_second: 2581.1929285938522
       failed_codepoints:
       - measured_by_terminal: 4
         measured_by_wcwidth: 2
@@ -4839,13 +4252,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\U0001f467\u200d\U0001f467
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f468\u200d\u2695\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f468\u200d\u2696\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f468\u200d\u2708\ufe0f
       - measured_by_terminal: 4
@@ -4887,13 +4300,13 @@ test_results:
       - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f468\u200d\U0001f692
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -4935,13 +4348,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fb\u200d\U0001f692
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -4983,13 +4396,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fc\u200d\U0001f692
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -5031,13 +4444,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fd\u200d\U0001f692
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -5079,13 +4492,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3fe\u200d\U0001f692
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -5127,13 +4540,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f468\U0001f3ff\u200d\U0001f692
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\u2695\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\u2696\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\u2708\ufe0f
       - measured_by_terminal: 4
@@ -5175,13 +4588,13 @@ test_results:
       - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f469\u200d\U0001f692
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -5223,13 +4636,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fb\u200d\U0001f692
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -5271,13 +4684,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fc\u200d\U0001f692
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -5319,13 +4732,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fd\u200d\U0001f692
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -5367,13 +4780,13 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3fe\u200d\U0001f692
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\u2695\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\u2696\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\u2708\ufe0f
       - measured_by_terminal: 6
@@ -5415,1491 +4828,1515 @@ test_results:
       - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f469\U0001f3ff\u200d\U0001f692
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \u26f9\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \u26f9\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \u26f9\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \u26f9\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \u26f9\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \u26f9\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \u26f9\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \u26f9\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \u26f9\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \u26f9\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
+        measured_by_wcwidth: 2
+        wchar: \u26f9\ufe0f\u200d\u2640\ufe0f
+      - measured_by_terminal: 4
+        measured_by_wcwidth: 2
+        wchar: \u26f9\ufe0f\u200d\u2642\ufe0f
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c3\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f3c4\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f3c4\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c4\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c4\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c4\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c4\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c4\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c4\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c4\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c4\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c4\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3c4\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f3ca\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f3ca\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3ca\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3ca\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3ca\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3ca\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3ca\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3ca\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3ca\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3ca\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3ca\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3ca\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cb\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cb\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cb\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cb\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cb\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cb\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cb\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cb\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cb\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cb\U0001f3ff\u200d\u2642\ufe0f
       - measured_by_terminal: 4
         measured_by_wcwidth: 2
-        wchar: \U0001f3cc\U0001f3fb\u200d\u2640\ufe0f
+        wchar: \U0001f3cb\ufe0f\u200d\u2640\ufe0f
       - measured_by_terminal: 4
+        measured_by_wcwidth: 2
+        wchar: \U0001f3cb\ufe0f\u200d\u2642\ufe0f
+      - measured_by_terminal: 6
+        measured_by_wcwidth: 2
+        wchar: \U0001f3cc\U0001f3fb\u200d\u2640\ufe0f
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cc\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cc\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cc\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cc\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cc\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cc\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cc\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cc\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f3cc\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
+        measured_by_wcwidth: 2
+        wchar: \U0001f3cc\ufe0f\u200d\u2640\ufe0f
+      - measured_by_terminal: 4
+        measured_by_wcwidth: 2
+        wchar: \U0001f3cc\ufe0f\u200d\u2642\ufe0f
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f46e\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f46e\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46e\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46e\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46e\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46e\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46e\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46e\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46e\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46e\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46e\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f46e\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f46f\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f46f\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f471\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f471\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f471\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f471\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f471\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f471\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f471\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f471\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f471\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f471\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f471\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f471\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f473\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f473\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f473\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f473\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f473\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f473\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f473\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f473\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f473\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f473\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f473\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f473\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f477\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f477\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f477\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f477\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f477\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f477\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f477\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f477\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f477\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f477\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f477\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f477\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f481\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f481\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f481\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f481\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f481\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f481\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f481\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f481\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f481\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f481\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f481\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f481\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f482\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f482\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f482\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f482\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f482\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f482\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f482\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f482\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f482\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f482\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f482\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f482\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f486\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f486\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f486\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f486\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f486\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f486\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f486\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f486\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f486\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f486\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f486\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f486\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f487\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f487\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f487\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f487\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f487\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f487\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f487\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f487\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f487\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f487\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f487\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f487\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f575\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f575\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f575\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f575\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f575\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f575\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f575\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f575\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f575\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 4
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f575\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
+        measured_by_wcwidth: 2
+        wchar: \U0001f575\ufe0f\u200d\u2640\ufe0f
+      - measured_by_terminal: 4
+        measured_by_wcwidth: 2
+        wchar: \U0001f575\ufe0f\u200d\u2642\ufe0f
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f645\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f645\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f645\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f645\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f645\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f645\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f645\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f645\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f645\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f645\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f645\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f645\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f646\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f646\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f646\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f646\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f646\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f646\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f646\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f646\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f646\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f646\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f646\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f646\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f647\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f647\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f647\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f647\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f647\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f647\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f647\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f647\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f647\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f647\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f647\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f647\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f64b\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f64b\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64b\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64b\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64b\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64b\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64b\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64b\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64b\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64b\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64b\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64b\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f64d\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f64d\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64d\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64d\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64d\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64d\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64d\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64d\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64d\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64d\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64d\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64d\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f64e\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f64e\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64e\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64e\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64e\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64e\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64e\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64e\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64e\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64e\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64e\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f64e\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f6a3\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f6a3\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6a3\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6a3\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6a3\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6a3\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6a3\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6a3\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6a3\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6a3\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6a3\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6a3\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f6b4\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f6b4\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b4\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b4\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b4\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b4\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b4\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b4\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b4\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b4\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b4\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b4\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f6b5\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f6b5\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b5\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b5\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b5\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b5\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b5\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b5\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b5\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b5\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b5\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b5\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f6b6\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f926\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f926\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f926\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f926\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f926\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f926\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f926\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f926\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f926\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f926\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f926\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f926\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f937\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f937\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f937\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f937\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f937\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f937\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f937\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f937\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f937\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f937\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f937\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f937\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f938\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f938\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f938\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f938\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f938\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f938\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f938\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f938\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f938\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f938\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f938\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f938\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f939\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f939\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f939\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f939\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f939\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f939\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f939\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f939\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f939\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f939\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f939\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f939\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f93c\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f93c\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f93d\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f93d\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93d\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93d\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93d\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93d\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93d\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93d\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93d\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93d\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93d\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93d\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f93e\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f93e\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93e\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93e\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93e\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93e\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93e\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93e\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93e\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93e\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93e\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f93e\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f3f3\ufe0f\u200d\U0001f308
-      n_errors: 571
+      n_errors: 579
       n_total: 579
-      pct_success: 1.381692573402418
-      seconds_elapsed: 0.12337266901158728
+      pct_success: 0.0
+      seconds_elapsed: 0.22431488696020097
     '5.0':
-      codepoints_per_second: 4746.318081740884
+      codepoints_per_second: 2653.2150108212304
       failed_codepoints:
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d6\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d6\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d6\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d6\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d6\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d6\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d6\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d6\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d6\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d6\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d6\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d6\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d7\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d7\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d7\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d7\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d7\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d7\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d7\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d7\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d7\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d7\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d7\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d7\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d8\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d8\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d8\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d8\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d8\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d8\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d8\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d8\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d8\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d8\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d8\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d8\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d9\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9d9\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d9\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d9\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d9\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d9\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d9\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d9\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d9\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d9\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d9\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9d9\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9da\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9da\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9da\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9da\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9da\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9da\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9da\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9da\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9da\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9da\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9da\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9da\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9db\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9db\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9db\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9db\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9db\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9db\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9db\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9db\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9db\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9db\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9db\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9db\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9dc\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9dc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dc\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dc\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dc\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dc\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dc\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dc\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dc\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dc\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dc\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dc\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9dd\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9dd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dd\U0001f3fb\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dd\U0001f3fb\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dd\U0001f3fc\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dd\U0001f3fc\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dd\U0001f3fd\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dd\U0001f3fd\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dd\U0001f3fe\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dd\U0001f3fe\u200d\u2642\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dd\U0001f3ff\u200d\u2640\ufe0f
-      - measured_by_terminal: 5
+      - measured_by_terminal: 6
         measured_by_wcwidth: 2
         wchar: \U0001f9dd\U0001f3ff\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9de\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9de\u200d\u2642\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9df\u200d\u2640\ufe0f
-      - measured_by_terminal: 3
+      - measured_by_terminal: 4
         measured_by_wcwidth: 2
         wchar: \U0001f9df\u200d\u2642\ufe0f
       n_errors: 100
       n_total: 100
       pct_success: 0.0
-      seconds_elapsed: 0.021068962989374995
+      seconds_elapsed: 0.03769012296106666
   emoji_zwj_version: null
   language_results:
     (Jinan):
-      codepoints_per_second: 2220.0564340023893
+      codepoints_per_second: 1349.7738443549824
       failed: []
       n_errors: 0
-      n_total: 211
+      n_total: 210
       pct_success: 100.0
-      seconds_elapsed: 0.09504262899281457
+      seconds_elapsed: 0.15558161900844425
     (Yeonbyeon):
-      codepoints_per_second: 2542.695158854574
+      codepoints_per_second: 1624.2805726819213
       failed: []
       n_errors: 0
       n_total: 1061
       pct_success: 100.0
-      seconds_elapsed: 0.4172737720073201
+      seconds_elapsed: 0.6532122700009495
     Aja:
-      codepoints_per_second: 2497.964667870234
+      codepoints_per_second: 1672.5026731015287
       failed: []
       n_errors: 0
       n_total: 2061
       pct_success: 100.0
-      seconds_elapsed: 0.8250717179907952
+      seconds_elapsed: 1.2322850259952247
     Amarakaeri:
-      codepoints_per_second: 2538.0946549955856
+      codepoints_per_second: 1662.598078773899
       failed: []
       n_errors: 0
       n_total: 1446
       pct_success: 100.0
-      seconds_elapsed: 0.5697187049954664
+      seconds_elapsed: 0.8697231269907206
     Arabic, Standard:
-      codepoints_per_second: 2555.6328036366044
+      codepoints_per_second: 1675.9511415477546
       failed: []
       n_errors: 0
       n_total: 1348
       pct_success: 100.0
-      seconds_elapsed: 0.5274623169971164
+      seconds_elapsed: 0.8043193900957704
     Assyrian Neo-Aramaic:
-      codepoints_per_second: 2618.696493403225
+      codepoints_per_second: 1717.4385905967397
       failed: []
       n_errors: 0
       n_total: 1160
       pct_success: 100.0
-      seconds_elapsed: 0.4429684779897798
+      seconds_elapsed: 0.6754244409967214
     Baatonum:
-      codepoints_per_second: 2410.0621902069474
+      codepoints_per_second: 1680.4262127418112
       failed: []
       n_errors: 0
       n_total: 1938
       pct_success: 100.0
-      seconds_elapsed: 0.8041286270017736
+      seconds_elapsed: 1.1532788439653814
     Bamun:
-      codepoints_per_second: 2514.166207019678
+      codepoints_per_second: 1670.365018170081
       failed: []
       n_errors: 0
       n_total: 2285
       pct_success: 100.0
-      seconds_elapsed: 0.908850017003715
+      seconds_elapsed: 1.3679644719231874
     Belanda Viri:
-      codepoints_per_second: 2402.391460661319
+      codepoints_per_second: 1629.65218408595
       failed: []
       n_errors: 0
       n_total: 2246
       pct_success: 100.0
-      seconds_elapsed: 0.9349017580098007
+      seconds_elapsed: 1.3782081980025396
     Bengali:
-      codepoints_per_second: 2182.4670439652377
+      codepoints_per_second: 1618.0719104707339
       failed:
       - measured_by_terminal: 12
         measured_by_wcwidth: 7
@@ -9904,9 +9341,9 @@ test_results:
       n_errors: 1000
       n_total: 1166
       pct_success: 14.236706689536879
-      seconds_elapsed: 0.5342577809933573
+      seconds_elapsed: 0.7206107419915497
     Bhojpuri:
-      codepoints_per_second: 2381.857038667748
+      codepoints_per_second: 1692.912708566096
       failed:
       - measured_by_terminal: 10
         measured_by_wcwidth: 6
@@ -12545,16 +11982,16 @@ test_results:
       n_errors: 878
       n_total: 1737
       pct_success: 49.453080023028214
-      seconds_elapsed: 0.7292629120056517
+      seconds_elapsed: 1.0260422709397972
     Bora:
-      codepoints_per_second: 2522.9662793606776
+      codepoints_per_second: 1646.1795315222935
       failed: []
       n_errors: 0
       n_total: 1598
       pct_success: 100.0
-      seconds_elapsed: 0.6333814340177923
+      seconds_elapsed: 0.9707325169583783
     Burmese:
-      codepoints_per_second: 2381.7409715152917
+      codepoints_per_second: 1665.493120465053
       failed:
       - measured_by_terminal: 11
         measured_by_wcwidth: 8
@@ -15481,16 +14918,16 @@ test_results:
       n_errors: 974
       n_total: 1223
       pct_success: 20.35977105478332
-      seconds_elapsed: 0.5134899280092213
+      seconds_elapsed: 0.7343170529929921
     Catalan (2):
-      codepoints_per_second: 2583.6160223938614
+      codepoints_per_second: 1671.4537150908334
       failed: []
       n_errors: 0
       n_total: 1909
       pct_success: 100.0
-      seconds_elapsed: 0.7388868870039005
+      seconds_elapsed: 1.1421195709845051
     Chakma:
-      codepoints_per_second: 2439.247838307217
+      codepoints_per_second: 1641.162245665001
       failed:
       - measured_by_terminal: 8
         measured_by_wcwidth: 7
@@ -16974,233 +16411,233 @@ test_results:
       n_errors: 493
       n_total: 1444
       pct_success: 65.85872576177285
-      seconds_elapsed: 0.5919857659901027
+      seconds_elapsed: 0.879864257061854
     Chickasaw:
-      codepoints_per_second: 2463.6650648393797
+      codepoints_per_second: 1645.9788860411427
       failed: []
       n_errors: 0
       n_total: 554
       pct_success: 100.0
-      seconds_elapsed: 0.22486822900827974
+      seconds_elapsed: 0.3365778289735317
     Chinantec, Chiltepec:
-      codepoints_per_second: 2512.622129665864
+      codepoints_per_second: 1650.078776492366
       failed: []
       n_errors: 0
       n_total: 1729
       pct_success: 100.0
-      seconds_elapsed: 0.6881257549975999
+      seconds_elapsed: 1.047828761045821
     Chinese, Gan:
-      codepoints_per_second: 2160.6808433868096
+      codepoints_per_second: 1368.1565211192465
       failed: []
       n_errors: 0
-      n_total: 211
+      n_total: 210
       pct_success: 100.0
-      seconds_elapsed: 0.09765440400224179
+      seconds_elapsed: 0.15349121007602662
     Chinese, Hakka:
-      codepoints_per_second: 2187.0154237645597
+      codepoints_per_second: 1400.915571225384
       failed: []
       n_errors: 0
-      n_total: 212
+      n_total: 211
       pct_success: 100.0
-      seconds_elapsed: 0.09693575897836126
+      seconds_elapsed: 0.1506157860858366
     Chinese, Jinyu:
-      codepoints_per_second: 1811.2851867034817
+      codepoints_per_second: 1292.299702132736
       failed: []
       n_errors: 0
-      n_total: 212
+      n_total: 211
       pct_success: 100.0
-      seconds_elapsed: 0.11704396500135772
+      seconds_elapsed: 0.16327481903135777
     Chinese, Mandarin (Beijing):
-      codepoints_per_second: 2069.480847286523
+      codepoints_per_second: 1415.4152737124336
       failed: []
       n_errors: 0
-      n_total: 212
+      n_total: 211
       pct_success: 100.0
-      seconds_elapsed: 0.10244115101522766
+      seconds_elapsed: 0.1490728579228744
     Chinese, Mandarin (Guiyang):
-      codepoints_per_second: 2100.52815175314
+      codepoints_per_second: 1416.8579747026083
       failed: []
       n_errors: 0
-      n_total: 211
+      n_total: 210
       pct_success: 100.0
-      seconds_elapsed: 0.10045092698419467
+      seconds_elapsed: 0.14821527898311615
     Chinese, Mandarin (Harbin):
-      codepoints_per_second: 2151.1627599005396
+      codepoints_per_second: 1387.8298291362464
       failed: []
       n_errors: 0
-      n_total: 210
+      n_total: 209
       pct_success: 100.0
-      seconds_elapsed: 0.09762162301922217
+      seconds_elapsed: 0.15059483202639967
     Chinese, Mandarin (Nanjing):
-      codepoints_per_second: 2105.076481374859
-      failed: []
-      n_errors: 0
-      n_total: 212
-      pct_success: 100.0
-      seconds_elapsed: 0.10070892999647185
-    Chinese, Mandarin (Simplified):
-      codepoints_per_second: 2122.327365116572
-      failed: []
-      n_errors: 0
-      n_total: 225
-      pct_success: 100.0
-      seconds_elapsed: 0.10601568999118172
-    Chinese, Mandarin (Tianjin):
-      codepoints_per_second: 2163.6844650685234
-      failed: []
-      n_errors: 0
-      n_total: 212
-      pct_success: 100.0
-      seconds_elapsed: 0.09798101498745382
-    Chinese, Mandarin (Traditional):
-      codepoints_per_second: 2019.5237942642054
-      failed: []
-      n_errors: 0
-      n_total: 210
-      pct_success: 100.0
-      seconds_elapsed: 0.10398491000523791
-    Chinese, Min Nan:
-      codepoints_per_second: 2106.863537021873
-      failed: []
-      n_errors: 0
-      n_total: 212
-      pct_success: 100.0
-      seconds_elapsed: 0.1006235080130864
-    Chinese, Wu:
-      codepoints_per_second: 2023.6509553315473
+      codepoints_per_second: 1377.9921930368573
       failed: []
       n_errors: 0
       n_total: 211
       pct_success: 100.0
-      seconds_elapsed: 0.10426699300296605
-    Chinese, Xiang:
-      codepoints_per_second: 2182.1013608754292
+      seconds_elapsed: 0.15312133193947375
+    Chinese, Mandarin (Simplified):
+      codepoints_per_second: 1402.4354519099093
       failed: []
       n_errors: 0
-      n_total: 212
+      n_total: 224
       pct_success: 100.0
-      seconds_elapsed: 0.09715405700262636
-    Chinese, Yue:
-      codepoints_per_second: 2142.532593136272
+      seconds_elapsed: 0.1597221459960565
+    Chinese, Mandarin (Tianjin):
+      codepoints_per_second: 1393.3367477848822
       failed: []
       n_errors: 0
       n_total: 210
       pct_success: 100.0
-      seconds_elapsed: 0.09801484498893842
+      seconds_elapsed: 0.150717334006913
+    Chinese, Mandarin (Traditional):
+      codepoints_per_second: 1408.9007475532153
+      failed: []
+      n_errors: 0
+      n_total: 209
+      pct_success: 100.0
+      seconds_elapsed: 0.1483425999758765
+    Chinese, Min Nan:
+      codepoints_per_second: 1352.6782129217845
+      failed: []
+      n_errors: 0
+      n_total: 211
+      pct_success: 100.0
+      seconds_elapsed: 0.15598684002179652
+    Chinese, Wu:
+      codepoints_per_second: 1314.0965454917182
+      failed: []
+      n_errors: 0
+      n_total: 210
+      pct_success: 100.0
+      seconds_elapsed: 0.15980560996104032
+    Chinese, Xiang:
+      codepoints_per_second: 1390.5900549045462
+      failed: []
+      n_errors: 0
+      n_total: 211
+      pct_success: 100.0
+      seconds_elapsed: 0.15173415001481771
+    Chinese, Yue:
+      codepoints_per_second: 1404.2133942960766
+      failed: []
+      n_errors: 0
+      n_total: 209
+      pct_success: 100.0
+      seconds_elapsed: 0.1488377769710496
     Colorado:
-      codepoints_per_second: 2290.693914889443
+      codepoints_per_second: 1508.2934842393838
       failed: []
       n_errors: 0
       n_total: 1263
       pct_success: 100.0
-      seconds_elapsed: 0.5513613109942526
+      seconds_elapsed: 0.8373701890232041
     Dagaare, Southern:
-      codepoints_per_second: 2524.858095830482
+      codepoints_per_second: 1706.5737346311237
       failed: []
       n_errors: 0
       n_total: 2582
       pct_success: 100.0
-      seconds_elapsed: 1.0226317289925646
+      seconds_elapsed: 1.512973009957932
     Dangme:
-      codepoints_per_second: 2540.903944175611
+      codepoints_per_second: 1655.9932848133712
       failed: []
       n_errors: 0
       n_total: 2912
       pct_success: 100.0
-      seconds_elapsed: 1.1460488330048975
+      seconds_elapsed: 1.7584612369537354
     Dari:
-      codepoints_per_second: 2501.8688839602537
+      codepoints_per_second: 1682.388504750579
       failed: []
       n_errors: 0
       n_total: 1872
       pct_success: 100.0
-      seconds_elapsed: 0.7482406500203069
+      seconds_elapsed: 1.1127037510741502
     Dendi:
-      codepoints_per_second: 2467.2238470817592
+      codepoints_per_second: 1728.2798677080093
       failed: []
       n_errors: 0
       n_total: 1569
       pct_success: 100.0
-      seconds_elapsed: 0.6359374330204446
+      seconds_elapsed: 0.9078390770591795
     Dinka, Northeastern:
-      codepoints_per_second: 2534.552578081121
+      codepoints_per_second: 1675.1779639935114
       failed: []
       n_errors: 0
       n_total: 1529
       pct_success: 100.0
-      seconds_elapsed: 0.603262293006992
+      seconds_elapsed: 0.9127388449851424
     Ditammari:
-      codepoints_per_second: 2458.031893953604
+      codepoints_per_second: 1655.2474383279227
       failed: []
       n_errors: 0
       n_total: 1882
       pct_success: 100.0
-      seconds_elapsed: 0.7656532059772871
+      seconds_elapsed: 1.1369901299476624
     Dzongkha:
-      codepoints_per_second: 2482.5391461228737
+      codepoints_per_second: 1664.3745591746585
       failed: []
       n_errors: 0
       n_total: 3060
       pct_success: 100.0
-      seconds_elapsed: 1.2326089619891718
+      seconds_elapsed: 1.8385284629184753
     Evenki:
-      codepoints_per_second: 2270.1837727025263
+      codepoints_per_second: 1560.839503035692
       failed: []
       n_errors: 0
       n_total: 899
       pct_success: 100.0
-      seconds_elapsed: 0.3960031830065418
+      seconds_elapsed: 0.5759720959467813
     Farsi, Western:
-      codepoints_per_second: 2499.999433996756
+      codepoints_per_second: 1686.4154243555854
       failed: []
       n_errors: 0
       n_total: 1822
       pct_success: 100.0
-      seconds_elapsed: 0.728800165001303
+      seconds_elapsed: 1.0803980879718438
     Fon:
-      codepoints_per_second: 2392.999401019209
+      codepoints_per_second: 1719.4205262023052
       failed: []
       n_errors: 0
       n_total: 2520
       pct_success: 100.0
-      seconds_elapsed: 1.0530717220099177
+      seconds_elapsed: 1.4656100480351597
     French (Welche):
-      codepoints_per_second: 2540.218721074903
+      codepoints_per_second: 1671.3156214223088
       failed: []
       n_errors: 0
       n_total: 1928
       pct_success: 100.0
-      seconds_elapsed: 0.7589897610014305
+      seconds_elapsed: 1.153582229046151
     Fur:
-      codepoints_per_second: 2526.2411477954056
+      codepoints_per_second: 1670.7091284011456
       failed: []
       n_errors: 0
       n_total: 1838
       pct_success: 100.0
-      seconds_elapsed: 0.7275631630036514
+      seconds_elapsed: 1.1001316559268162
     Ga:
-      codepoints_per_second: 2471.4963082590402
+      codepoints_per_second: 1655.1699043456333
       failed: []
       n_errors: 0
       n_total: 2039
       pct_success: 100.0
-      seconds_elapsed: 0.8250062899896875
+      seconds_elapsed: 1.2318977010436356
     Gen:
-      codepoints_per_second: 2517.376820333851
+      codepoints_per_second: 1669.5421499135637
       failed: []
       n_errors: 0
       n_total: 2309
       pct_success: 100.0
-      seconds_elapsed: 0.9172246210218873
+      seconds_elapsed: 1.3830139000201598
     Gilyak:
-      codepoints_per_second: 2390.2741967064685
+      codepoints_per_second: 1656.8840515615636
       failed: []
       n_errors: 0
       n_total: 1504
       pct_success: 100.0
-      seconds_elapsed: 0.6292165150225628
+      seconds_elapsed: 0.9077279720222577
     Gujarati:
-      codepoints_per_second: 2454.257654781285
+      codepoints_per_second: 1648.041399133353
       failed:
       - measured_by_terminal: 4
         measured_by_wcwidth: 3
@@ -20205,16 +19642,16 @@ test_results:
       n_errors: 1000
       n_total: 1520
       pct_success: 34.21052631578947
-      seconds_elapsed: 0.6193318770092446
+      seconds_elapsed: 0.9223069279687479
     Gumuz:
-      codepoints_per_second: 2578.119808293334
+      codepoints_per_second: 1635.2818876621243
       failed: []
       n_errors: 0
       n_total: 1283
       pct_success: 100.0
-      seconds_elapsed: 0.49764948699157685
+      seconds_elapsed: 0.7845742129720747
     Hindi:
-      codepoints_per_second: 2486.3205901542224
+      codepoints_per_second: 1654.4472809745766
       failed:
       - measured_by_terminal: 4
         measured_by_wcwidth: 3
@@ -23219,30 +22656,30 @@ test_results:
       n_errors: 1000
       n_total: 1632
       pct_success: 38.72549019607843
-      seconds_elapsed: 0.6563916199957021
+      seconds_elapsed: 0.9864321569912136
     Japanese:
-      codepoints_per_second: 1911.672691307571
+      codepoints_per_second: 1379.44528262108
       failed: []
       n_errors: 0
-      n_total: 299
+      n_total: 287
       pct_success: 100.0
-      seconds_elapsed: 0.15640752800391056
+      seconds_elapsed: 0.208054646034725
     Japanese (Osaka):
-      codepoints_per_second: 2212.4572088348164
+      codepoints_per_second: 1448.0998020642016
       failed: []
       n_errors: 0
-      n_total: 308
+      n_total: 296
       pct_success: 100.0
-      seconds_elapsed: 0.13921173199196346
+      seconds_elapsed: 0.20440580102149397
     Japanese (Tokyo):
-      codepoints_per_second: 2182.577430720833
+      codepoints_per_second: 1408.8402297520868
       failed: []
       n_errors: 0
-      n_total: 320
+      n_total: 311
       pct_success: 100.0
-      seconds_elapsed: 0.1466156460228376
+      seconds_elapsed: 0.22074894898105413
     Javanese (Javanese):
-      codepoints_per_second: 2368.029716190781
+      codepoints_per_second: 1588.395777372716
       failed:
       - measured_by_terminal: 5
         measured_by_wcwidth: 4
@@ -24897,16 +24334,16 @@ test_results:
       n_errors: 550
       n_total: 1453
       pct_success: 62.14728148657949
-      seconds_elapsed: 0.6135902729874942
+      seconds_elapsed: 0.914759419974871
     Kabyle:
-      codepoints_per_second: 2423.5173217662855
+      codepoints_per_second: 1648.1416469603469
       failed: []
       n_errors: 0
       n_total: 1815
       pct_success: 100.0
-      seconds_elapsed: 0.7489115030039102
+      seconds_elapsed: 1.101240298943594
     Kannada:
-      codepoints_per_second: 2283.216895907201
+      codepoints_per_second: 1612.9300020114297
       failed:
       - measured_by_terminal: 4
         measured_by_wcwidth: 3
@@ -27617,9 +27054,9 @@ test_results:
       n_errors: 902
       n_total: 1080
       pct_success: 16.48148148148148
-      seconds_elapsed: 0.4730168219830375
+      seconds_elapsed: 0.6695888839894906
     Khmer, Central:
-      codepoints_per_second: 2397.6630631837056
+      codepoints_per_second: 1571.7946406220062
       failed:
       - measured_by_terminal: 25
         measured_by_wcwidth: 22
@@ -28968,9 +28405,9 @@ test_results:
       n_errors: 448
       n_total: 528
       pct_success: 15.151515151515152
-      seconds_elapsed: 0.22021442800178193
+      seconds_elapsed: 0.33592174598015845
     "Kh\xFCn":
-      codepoints_per_second: 2382.9073304237027
+      codepoints_per_second: 1630.4413526602568
       failed:
       - measured_by_terminal: 15
         measured_by_wcwidth: 12
@@ -30058,37 +29495,37 @@ test_results:
       n_errors: 361
       n_total: 442
       pct_success: 18.32579185520362
-      seconds_elapsed: 0.1854876999859698
+      seconds_elapsed: 0.2710922409314662
     Korean:
-      codepoints_per_second: 2382.412291845921
+      codepoints_per_second: 1633.8927228612808
       failed: []
       n_errors: 0
       n_total: 1185
       pct_success: 100.0
-      seconds_elapsed: 0.49739501599106006
+      seconds_elapsed: 0.7252618139609694
     Lamnso':
-      codepoints_per_second: 2391.948761560214
+      codepoints_per_second: 1657.4892086816817
       failed: []
       n_errors: 0
       n_total: 2237
       pct_success: 100.0
-      seconds_elapsed: 0.9352207020274363
+      seconds_elapsed: 1.3496317130047828
     Lao:
-      codepoints_per_second: 2287.4784700809378
+      codepoints_per_second: 1588.5524044026038
       failed: []
       n_errors: 0
-      n_total: 426
+      n_total: 411
       pct_success: 100.0
-      seconds_elapsed: 0.18623126100283116
+      seconds_elapsed: 0.2587261199951172
     Lingala (tones):
-      codepoints_per_second: 2359.7232590638673
+      codepoints_per_second: 1680.5130247955174
       failed: []
       n_errors: 0
       n_total: 1818
       pct_success: 100.0
-      seconds_elapsed: 0.7704293259885162
+      seconds_elapsed: 1.0818125020014122
     Magahi:
-      codepoints_per_second: 2466.6322194112913
+      codepoints_per_second: 1679.205325200711
       failed:
       - measured_by_terminal: 10
         measured_by_wcwidth: 6
@@ -32523,9 +31960,9 @@ test_results:
       n_errors: 810
       n_total: 1716
       pct_success: 52.7972027972028
-      seconds_elapsed: 0.6956853909941856
+      seconds_elapsed: 1.0219119569519535
     Maithili:
-      codepoints_per_second: 2455.3835830472426
+      codepoints_per_second: 1674.0165082646427
       failed:
       - measured_by_terminal: 7
         measured_by_wcwidth: 5
@@ -35389,9 +34826,9 @@ test_results:
       n_errors: 953
       n_total: 1519
       pct_success: 37.26135615536537
-      seconds_elapsed: 0.6186406109773088
+      seconds_elapsed: 0.9073984590359032
     Malayalam:
-      codepoints_per_second: 8266.196173142933
+      codepoints_per_second: 5422.283372884965
       failed:
       - measured_by_terminal: 21
         measured_by_wcwidth: 17
@@ -38396,23 +37833,23 @@ test_results:
       n_errors: 1000
       n_total: 1156
       pct_success: 13.494809688581316
-      seconds_elapsed: 0.13984666898613796
+      seconds_elapsed: 0.213194316951558
     Maldivian:
-      codepoints_per_second: 2519.012049725572
+      codepoints_per_second: 1657.3364787741527
       failed: []
       n_errors: 0
       n_total: 1918
       pct_success: 100.0
-      seconds_elapsed: 0.7614096170000266
+      seconds_elapsed: 1.1572785759344697
     Maori (2):
-      codepoints_per_second: 2494.1005450432094
+      codepoints_per_second: 1690.3216826732184
       failed: []
       n_errors: 0
       n_total: 2385
       pct_success: 100.0
-      seconds_elapsed: 0.9562565569940489
+      seconds_elapsed: 1.4109740320127457
     Marathi:
-      codepoints_per_second: 2449.1962244082574
+      codepoints_per_second: 1634.2242655852478
       failed:
       - measured_by_terminal: 5
         measured_by_wcwidth: 3
@@ -41417,30 +40854,30 @@ test_results:
       n_errors: 1000
       n_total: 1421
       pct_success: 29.62702322308234
-      seconds_elapsed: 0.5801903440151364
+      seconds_elapsed: 0.8695257009239867
     Mazahua Central:
-      codepoints_per_second: 2451.8866240178827
+      codepoints_per_second: 1662.7294592261296
       failed: []
       n_errors: 0
       n_total: 1574
       pct_success: 100.0
-      seconds_elapsed: 0.6419546420220286
+      seconds_elapsed: 0.9466362620005384
     Mirandese:
-      codepoints_per_second: 2570.7699761205313
+      codepoints_per_second: 1622.9504786478117
       failed: []
       n_errors: 0
       n_total: 1966
       pct_success: 100.0
-      seconds_elapsed: 0.7647514239943121
+      seconds_elapsed: 1.2113739919150248
     "Mixtec, Metlat\xF3noc":
-      codepoints_per_second: 2317.141451706204
+      codepoints_per_second: 1688.7700122084027
       failed: []
       n_errors: 0
       n_total: 1367
       pct_success: 100.0
-      seconds_elapsed: 0.5899510360031854
+      seconds_elapsed: 0.8094648709520698
     Mon:
-      codepoints_per_second: 2421.499683655869
+      codepoints_per_second: 1644.523513930156
       failed:
       - measured_by_terminal: 7
         measured_by_wcwidth: 5
@@ -43473,37 +42910,37 @@ test_results:
       n_errors: 676
       n_total: 946
       pct_success: 28.541226215644823
-      seconds_elapsed: 0.3906669930147473
+      seconds_elapsed: 0.5752426109975204
     Mongolian, Halh (Mongolian):
-      codepoints_per_second: 1866.3221337219622
+      codepoints_per_second: 1401.974041842708
       failed: []
       n_errors: 0
       n_total: 33
       pct_success: 100.0
-      seconds_elapsed: 0.017681834986433387
+      seconds_elapsed: 0.02353823895100504
     "M\xF2or\xE9":
-      codepoints_per_second: 2437.840628062163
+      codepoints_per_second: 1685.6165849378665
       failed: []
       n_errors: 0
       n_total: 2447
       pct_success: 100.0
-      seconds_elapsed: 1.0037571660068352
+      seconds_elapsed: 1.4516943069174886
     Nanai:
-      codepoints_per_second: 2335.028025865054
+      codepoints_per_second: 1569.225066235407
       failed: []
       n_errors: 0
       n_total: 1207
       pct_success: 100.0
-      seconds_elapsed: 0.5169102840009145
+      seconds_elapsed: 0.7691694620298222
     Navajo:
-      codepoints_per_second: 2477.378560888305
+      codepoints_per_second: 1688.5187123269407
       failed: []
       n_errors: 0
       n_total: 1600
       pct_success: 100.0
-      seconds_elapsed: 0.6458439679990988
+      seconds_elapsed: 0.9475761140929535
     Nepali:
-      codepoints_per_second: 2411.719352692968
+      codepoints_per_second: 1717.7056162623833
       failed:
       - measured_by_terminal: 4
         measured_by_wcwidth: 3
@@ -46301,30 +45738,30 @@ test_results:
       n_errors: 931
       n_total: 1385
       pct_success: 32.7797833935018
-      seconds_elapsed: 0.57427909199032
+      seconds_elapsed: 0.8063081280561164
     Nuosu:
-      codepoints_per_second: 1998.0036640816386
+      codepoints_per_second: 1307.160226167294
       failed: []
       n_errors: 0
-      n_total: 230
+      n_total: 229
       pct_success: 100.0
-      seconds_elapsed: 0.11511490400880575
+      seconds_elapsed: 0.17518892895895988
     Orok:
-      codepoints_per_second: 2199.9965008114013
+      codepoints_per_second: 1615.689596485644
       failed: []
       n_errors: 0
       n_total: 1245
       pct_success: 100.0
-      seconds_elapsed: 0.565909991011722
+      seconds_elapsed: 0.7705688040005043
     Otomi, Mezquital:
-      codepoints_per_second: 2338.0833644726995
+      codepoints_per_second: 1619.25395913659
       failed: []
       n_errors: 0
       n_total: 1849
       pct_success: 100.0
-      seconds_elapsed: 0.7908186799904797
+      seconds_elapsed: 1.141883883974515
     Panjabi, Eastern:
-      codepoints_per_second: 2448.200734608317
+      codepoints_per_second: 1689.964280307243
       failed:
       - measured_by_terminal: 4
         measured_by_wcwidth: 3
@@ -49329,44 +48766,44 @@ test_results:
       n_errors: 1000
       n_total: 1834
       pct_success: 45.47437295528899
-      seconds_elapsed: 0.7491215789923444
+      seconds_elapsed: 1.0852300379192457
     Panjabi, Western:
-      codepoints_per_second: 2422.129342683903
+      codepoints_per_second: 1675.4777727017588
       failed: []
       n_errors: 0
       n_total: 2419
       pct_success: 100.0
-      seconds_elapsed: 0.9987080199935008
+      seconds_elapsed: 1.4437672880012542
     Pashto, Northern:
-      codepoints_per_second: 2393.2825618406846
+      codepoints_per_second: 1712.5282640425708
       failed: []
       n_errors: 0
       n_total: 2242
       pct_success: 100.0
-      seconds_elapsed: 0.936788674996933
+      seconds_elapsed: 1.309175472939387
     Picard:
-      codepoints_per_second: 2424.221161199416
+      codepoints_per_second: 1654.1661558507221
       failed: []
       n_errors: 0
       n_total: 2024
       pct_success: 100.0
-      seconds_elapsed: 0.8349073229765054
+      seconds_elapsed: 1.223577204043977
     Pular (Adlam):
-      codepoints_per_second: 2533.0974504751853
+      codepoints_per_second: 1675.1278329364845
       failed: []
       n_errors: 0
       n_total: 1613
       pct_success: 100.0
-      seconds_elapsed: 0.6367698170070071
+      seconds_elapsed: 0.9629115869756788
     Saint Lucian Creole French:
-      codepoints_per_second: 2534.5727418090514
+      codepoints_per_second: 1699.7383995339626
       failed: []
       n_errors: 0
       n_total: 1777
       pct_success: 100.0
-      seconds_elapsed: 0.7011043599923141
+      seconds_elapsed: 1.0454549950081855
     Sanskrit:
-      codepoints_per_second: 2413.8441337867084
+      codepoints_per_second: 1609.5000755206045
       failed:
       - measured_by_terminal: 13
         measured_by_wcwidth: 7
@@ -51633,9 +51070,9 @@ test_results:
       n_errors: 754
       n_total: 1000
       pct_success: 24.6
-      seconds_elapsed: 0.41427695599850267
+      seconds_elapsed: 0.6213109369855374
     Sanskrit (Grantha):
-      codepoints_per_second: 2386.606206546429
+      codepoints_per_second: 1588.579150486116
       failed:
       - measured_by_terminal: 14
         measured_by_wcwidth: 7
@@ -54319,23 +53756,23 @@ test_results:
       n_errors: 893
       n_total: 1006
       pct_success: 11.232604373757455
-      seconds_elapsed: 0.4215190579998307
+      seconds_elapsed: 0.6332703030202538
     Secoya:
-      codepoints_per_second: 2426.8798330368168
+      codepoints_per_second: 1667.386192939649
       failed: []
       n_errors: 0
       n_total: 1409
       pct_success: 100.0
-      seconds_elapsed: 0.5805808680015616
+      seconds_elapsed: 0.8450351849896833
     Seraiki:
-      codepoints_per_second: 2565.5278142632287
+      codepoints_per_second: 1706.7251438466574
       failed: []
       n_errors: 0
       n_total: 2242
       pct_success: 100.0
-      seconds_elapsed: 0.8738942480122205
+      seconds_elapsed: 1.313626864925027
     Shan:
-      codepoints_per_second: 2530.6967430358254
+      codepoints_per_second: 1705.9154812381373
       failed:
       - measured_by_terminal: 9
         measured_by_wcwidth: 6
@@ -56944,16 +56381,16 @@ test_results:
       n_errors: 868
       n_total: 915
       pct_success: 5.136612021857923
-      seconds_elapsed: 0.3615605079976376
+      seconds_elapsed: 0.5363688940415159
     Shipibo-Conibo:
-      codepoints_per_second: 2454.9032935889604
+      codepoints_per_second: 1662.0833224737237
       failed: []
       n_errors: 0
       n_total: 2540
       pct_success: 100.0
-      seconds_elapsed: 1.0346639750059694
+      seconds_elapsed: 1.5282025670167059
     Sinhala:
-      codepoints_per_second: 2480.3146121904538
+      codepoints_per_second: 1632.0175550613237
       failed:
       - measured_by_terminal: 4
         measured_by_wcwidth: 3
@@ -59613,37 +59050,37 @@ test_results:
       n_errors: 885
       n_total: 1655
       pct_success: 46.52567975830816
-      seconds_elapsed: 0.667254061991116
+      seconds_elapsed: 1.0140822289977223
     Siona:
-      codepoints_per_second: 2403.1318142097316
+      codepoints_per_second: 1671.3699711822608
       failed: []
       n_errors: 0
       n_total: 1492
       pct_success: 100.0
-      seconds_elapsed: 0.6208564970002044
+      seconds_elapsed: 0.8926808700198308
     South Azerbaijani:
-      codepoints_per_second: 2588.4342309638982
+      codepoints_per_second: 1646.4793498058345
       failed: []
       n_errors: 0
       n_total: 1396
       pct_success: 100.0
-      seconds_elapsed: 0.5393221830017865
+      seconds_elapsed: 0.8478697289247066
     Tagalog (Tagalog):
-      codepoints_per_second: 2355.758790402734
+      codepoints_per_second: 1711.1820552011395
       failed: []
       n_errors: 0
       n_total: 31
       pct_success: 100.0
-      seconds_elapsed: 0.013159241992980242
+      seconds_elapsed: 0.01811613200698048
     Tai Dam:
-      codepoints_per_second: 2497.887594272307
+      codepoints_per_second: 1662.0791458838619
       failed: []
       n_errors: 0
       n_total: 2386
       pct_success: 100.0
-      seconds_elapsed: 0.9552071139914915
+      seconds_elapsed: 1.4355513730552047
     Tamang, Eastern:
-      codepoints_per_second: 2444.3200211545477
+      codepoints_per_second: 1784.1640447917528
       failed:
       - measured_by_terminal: 4
         measured_by_wcwidth: 3
@@ -59747,16 +59184,16 @@ test_results:
       n_errors: 33
       n_total: 45
       pct_success: 26.666666666666668
-      seconds_elapsed: 0.018410027987556532
+      seconds_elapsed: 0.025221896008588374
     Tamazight, Central Atlas:
-      codepoints_per_second: 2503.451871264063
+      codepoints_per_second: 1681.0276557750299
       failed: []
       n_errors: 0
       n_total: 1822
       pct_success: 100.0
-      seconds_elapsed: 0.7277950980060268
+      seconds_elapsed: 1.0838608120102435
     Tamil:
-      codepoints_per_second: 2276.0484701441587
+      codepoints_per_second: 1567.8562275250606
       failed:
       - measured_by_terminal: 4
         measured_by_wcwidth: 3
@@ -62761,9 +62198,9 @@ test_results:
       n_errors: 1000
       n_total: 1075
       pct_success: 6.976744186046512
-      seconds_elapsed: 0.4723098009999376
+      seconds_elapsed: 0.6856496030231938
     Tamil (Sri Lanka):
-      codepoints_per_second: 2341.167787529746
+      codepoints_per_second: 1584.53748724639
       failed:
       - measured_by_terminal: 4
         measured_by_wcwidth: 3
@@ -65768,9 +65205,9 @@ test_results:
       n_errors: 1000
       n_total: 1074
       pct_success: 6.890130353817504
-      seconds_elapsed: 0.4587454200081993
+      seconds_elapsed: 0.6778003099607304
     Telugu:
-      codepoints_per_second: 2250.610467094627
+      codepoints_per_second: 1468.840987575485
       failed:
       - measured_by_terminal: 10
         measured_by_wcwidth: 9
@@ -67920,668 +67357,197 @@ test_results:
       n_errors: 715
       n_total: 1129
       pct_success: 36.6696191319752
-      seconds_elapsed: 0.5016416730068158
+      seconds_elapsed: 0.7686332350131124
     Tem:
-      codepoints_per_second: 2444.5564648357404
+      codepoints_per_second: 1690.7117849765355
       failed: []
       n_errors: 0
       n_total: 1659
       pct_success: 100.0
-      seconds_elapsed: 0.6786507179785985
+      seconds_elapsed: 0.9812435299390927
     Thai:
-      codepoints_per_second: 2362.1611432032823
+      codepoints_per_second: 1570.594668937691
       failed: []
       n_errors: 0
-      n_total: 341
+      n_total: 338
       pct_success: 100.0
-      seconds_elapsed: 0.14435933000640944
+      seconds_elapsed: 0.21520511095877737
     Thai (2):
-      codepoints_per_second: 2383.296281623085
+      codepoints_per_second: 1564.7960553673654
       failed: []
       n_errors: 0
-      n_total: 313
+      n_total: 309
       pct_success: 100.0
-      seconds_elapsed: 0.13133071301854216
+      seconds_elapsed: 0.19746982294600457
     Tibetan, Central:
-      codepoints_per_second: 2543.498677557658
+      codepoints_per_second: 1680.7856954657411
       failed: []
       n_errors: 0
       n_total: 3174
       pct_success: 100.0
-      seconds_elapsed: 1.2478874190128408
+      seconds_elapsed: 1.8884025539737195
     Ticuna:
-      codepoints_per_second: 2531.425966155211
+      codepoints_per_second: 1670.9221809332798
       failed: []
       n_errors: 0
       n_total: 2048
       pct_success: 100.0
-      seconds_elapsed: 0.8090301780030131
+      seconds_elapsed: 1.2256704850587994
     Uduk:
-      codepoints_per_second: 2549.112769322947
+      codepoints_per_second: 1688.185014413045
       failed: []
       n_errors: 0
       n_total: 3247
       pct_success: 100.0
-      seconds_elapsed: 1.2737765229830984
+      seconds_elapsed: 1.9233673870330676
     Urdu:
-      codepoints_per_second: 2462.055937409438
+      codepoints_per_second: 1678.4738207724874
       failed: []
       n_errors: 0
       n_total: 2237
       pct_success: 100.0
-      seconds_elapsed: 0.9085902420047205
+      seconds_elapsed: 1.332758350064978
     Urdu (2):
-      codepoints_per_second: 2441.3097954625136
+      codepoints_per_second: 1665.7854505399869
       failed: []
       n_errors: 0
       n_total: 2251
       pct_success: 100.0
-      seconds_elapsed: 0.9220460279902909
+      seconds_elapsed: 1.3513144800672308
     Veps:
-      codepoints_per_second: 2370.0652483407493
+      codepoints_per_second: 1642.887994776093
       failed: []
       n_errors: 0
       n_total: 1323
       pct_success: 100.0
-      seconds_elapsed: 0.5582124799839221
+      seconds_elapsed: 0.805289224954322
     Vietnamese:
-      codepoints_per_second: 2467.3575158635826
+      codepoints_per_second: 1708.014780462663
       failed: []
       n_errors: 0
       n_total: 2502
       pct_success: 100.0
-      seconds_elapsed: 1.0140403179975692
+      seconds_elapsed: 1.4648585179820657
     Vietnamese (Han nom):
-      codepoints_per_second: 1841.7660149568171
+      codepoints_per_second: 1152.8272476488162
       failed: []
       n_errors: 0
-      n_total: 199
+      n_total: 194
       pct_success: 100.0
-      seconds_elapsed: 0.10804846999235451
+      seconds_elapsed: 0.16828193503897637
     Waama:
-      codepoints_per_second: 2336.179222467154
+      codepoints_per_second: 1690.004664810398
       failed: []
       n_errors: 0
       n_total: 1000
       pct_success: 100.0
-      seconds_elapsed: 0.4280493510013912
+      seconds_elapsed: 0.5917143430560827
     "Yanesha\u02BC":
-      codepoints_per_second: 2538.231542108691
+      codepoints_per_second: 1695.530832688147
       failed: []
       n_errors: 0
       n_total: 2536
       pct_success: 100.0
-      seconds_elapsed: 0.9991208279971033
+      seconds_elapsed: 1.4956967759644613
     Yiddish, Eastern:
-      codepoints_per_second: 2385.5394356613747
+      codepoints_per_second: 1592.0373562697657
       failed: []
       n_errors: 0
       n_total: 1775
       pct_success: 100.0
-      seconds_elapsed: 0.7440665090107359
+      seconds_elapsed: 1.1149235870689154
     Yoruba:
-      codepoints_per_second: 2503.2031437549936
+      codepoints_per_second: 1724.630182336715
       failed: []
       n_errors: 0
       n_total: 2454
       pct_success: 100.0
-      seconds_elapsed: 0.9803439269890077
+      seconds_elapsed: 1.4229137499351054
     "\xC9w\xE9":
-      codepoints_per_second: 2507.7250695784505
+      codepoints_per_second: 1647.7209032021112
       failed: []
       n_errors: 0
       n_total: 2230
       pct_success: 100.0
-      seconds_elapsed: 0.8892521859961562
+      seconds_elapsed: 1.3533845420461148
   unicode_wide_results:
     10.0.0:
-      codepoints_per_second: 4429.375741186401
+      codepoints_per_second: 2640.1451881786306
       failed_codepoints: []
       n_errors: 0
       n_total: 745
       pct_success: 100.0
-      seconds_elapsed: 0.16819525900064036
+      seconds_elapsed: 0.28218145098071545
     11.0.0:
-      codepoints_per_second: 4630.655985217008
+      codepoints_per_second: 2444.1087477969045
       failed_codepoints: []
       n_errors: 0
       n_total: 72
       pct_success: 100.0
-      seconds_elapsed: 0.015548552997643128
+      seconds_elapsed: 0.02945859101600945
     12.0.0:
-      codepoints_per_second: 4380.131812564464
+      codepoints_per_second: 2280.4178856446674
       failed_codepoints: []
       n_errors: 0
       n_total: 76
       pct_success: 100.0
-      seconds_elapsed: 0.017351076006889343
+      seconds_elapsed: 0.03332722501363605
     12.1.0:
-      codepoints_per_second: 2199.9730807297665
+      codepoints_per_second: 1593.7499648871387
       failed_codepoints: []
       n_errors: 0
       n_total: 1
       pct_success: 100.0
-      seconds_elapsed: 0.000454551016446203
+      seconds_elapsed: 0.0006274509942159057
     13.0.0:
-      codepoints_per_second: 4150.876136407787
+      codepoints_per_second: 2400.0260766999345
       failed_codepoints: []
       n_errors: 0
       n_total: 552
       pct_success: 100.0
-      seconds_elapsed: 0.13298397298785858
+      seconds_elapsed: 0.2299975010100752
     14.0.0:
-      codepoints_per_second: 4978.718734462013
+      codepoints_per_second: 2332.9238789296533
       failed_codepoints: []
       n_errors: 0
       n_total: 54
       pct_success: 100.0
-      seconds_elapsed: 0.01084616401931271
+      seconds_elapsed: 0.0231469189748168
     15.0.0:
-      codepoints_per_second: 4498.193773859012
+      codepoints_per_second: 2790.584171617538
       failed_codepoints: []
       n_errors: 0
       n_total: 22
       pct_success: 100.0
-      seconds_elapsed: 0.004890851996606216
+      seconds_elapsed: 0.007883653976023197
     15.1.0:
-      codepoints_per_second: 4289.816620429266
+      codepoints_per_second: 78.76379287612838
       failed_codepoints: []
       n_errors: 0
       n_total: 5
       pct_success: 100.0
-      seconds_elapsed: 0.0011655509879346937
+      seconds_elapsed: 0.06348094495479017
     16.0.0:
-      codepoints_per_second: 2778.934848810763
+      codepoints_per_second: 2502.9424119324754
       failed_codepoints: []
       n_errors: 0
       n_total: 198
       pct_success: 100.0
-      seconds_elapsed: 0.07125032099429518
+      seconds_elapsed: 0.07910689397249371
     17.0.0:
-      codepoints_per_second: 780.7937625062433
-      failed_codepoints:
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00016ff2
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00016ff3
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00016ff4
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00016ff5
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00016ff6
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U000187f8
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U000187f9
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U000187fa
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U000187fb
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U000187fc
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U000187fd
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U000187fe
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U000187ff
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d09
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d0a
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d0b
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d0c
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d0d
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d0e
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d0f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d10
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d11
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d12
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d13
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d14
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d15
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d16
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d17
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d18
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d19
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d1a
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d1b
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d1c
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d1d
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d1e
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d80
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d81
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d82
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d83
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d84
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d85
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d86
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d87
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d88
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d89
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d8a
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d8b
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d8c
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d8d
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d8e
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d8f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d90
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d91
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d92
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d93
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d94
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d95
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d96
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d97
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d98
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d99
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d9a
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d9b
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d9c
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d9d
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d9e
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018d9f
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018da0
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018da1
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018da2
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018da3
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018da4
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018da5
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018da6
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018da7
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018da8
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018da9
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018daa
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dab
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dac
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dad
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dae
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018daf
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018db0
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018db1
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018db2
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018db3
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018db4
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018db5
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018db6
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018db7
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018db8
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018db9
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dba
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dbb
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dbc
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dbd
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dbe
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dbf
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dc0
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dc1
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dc2
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dc3
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dc4
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dc5
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dc6
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dc7
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dc8
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dc9
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dca
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dcb
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dcc
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dcd
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dce
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dcf
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dd0
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dd1
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dd2
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dd3
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dd4
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dd5
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dd6
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dd7
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dd8
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dd9
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dda
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018ddb
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018ddc
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018ddd
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dde
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018ddf
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018de0
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018de1
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018de2
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018de3
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018de4
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018de5
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018de6
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018de7
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018de8
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018de9
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dea
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018deb
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dec
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018ded
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018dee
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018def
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018df0
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018df1
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U00018df2
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001f6d8
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001fa8a
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001fa8e
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001fac8
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001facd
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001faea
-      - measured_by_terminal: 1
-        measured_by_wcwidth: 2
-        wchar: \U0001faef
-      n_errors: 157
+      codepoints_per_second: 2616.465721787529
+      failed_codepoints: []
+      n_errors: 0
       n_total: 157
-      pct_success: 0.0
-      seconds_elapsed: 0.2010774259979371
+      pct_success: 100.0
+      seconds_elapsed: 0.06000460800714791
     9.0.0:
-      codepoints_per_second: 3739.6765499362377
+      codepoints_per_second: 2702.403936667734
       failed_codepoints: []
       n_errors: 0
       n_total: 5000
       pct_success: 100.0
-      seconds_elapsed: 1.3370140260085464
-  unicode_wide_version: 16.0.0
+      seconds_elapsed: 1.8502045279601589
+  unicode_wide_version: 17.0.0
 wcwidth_version: 0.2.14
-width: 170
+width: 80


### PR DESCRIPTION
Hi,

Author and maintainer of [Bobcat](https://github.com/ismail-yilmaz/Bobcat) here.

Thanks for the ucs-detect!

This PR aims to update the `data/bobcat.yaml` file. 

`r351` of Bobcat is currently available via `AUR`, but the official release page will be updated this weekend.

If anything else needs to be done, please let me know.

