### PR TITLE
Fully implement the kitty keyboard test.   Compliant implementations …

### DIFF
--- a/scripts/make_results_rst.py
+++ b/scripts/make_results_rst.py
@@ -1073,13 +1073,31 @@ def _classify_xtgettcap(data):
     return ("partial", 0.5)
 
 
+#: Kitty keyboard progressive enhancement flag keys recorded by
+#: maybe_determine_kitty_keyboard()
+KITTY_KB_FLAG_KEYS = ("disambiguate", "report_events", "report_alternates",
+                      "report_all_keys", "report_text")
+
+
 def _classify_kitty_keyboard(tr):
-    """Classify Kitty keyboard state: full (any flag set) / partial (all False) / None."""
+    """Classify Kitty keyboard support as full, partial, or none.
+
+    Returns ``(label, score)`` where label is "full", "partial", or None,
+    and score is 1.0, 0.5, or 0.0.
+
+    New-style records (marked by ``supported_flags``) measured which flags the
+    terminal honors when actively enabled: Full requires all five flags plus a
+    working push/pop stack.  Legacy records only queried the flags at rest
+    (always 0 on a conformant terminal) and cannot distinguish depth of
+    support, so they remain "partial".
+    """
     kk = tr.get("kitty_keyboard")
     if kk is None:
         return None, 0.0
-    if any(kk.values()):
-        return "full", 1.0
+    if "supported_flags" in kk:
+        n_flags = sum(bool(kk.get(key)) for key in KITTY_KB_FLAG_KEYS)
+        if n_flags == len(KITTY_KB_FLAG_KEYS) and kk.get("flag_stack"):
+            return "full", 1.0
     return "partial", 0.5
 
 
@@ -3341,6 +3359,14 @@ def show_kitty_keyboard_results(sw_name, entry):
     print(f"*{sw_name}* supports the `Kitty keyboard protocol`_.")
     print()
 
+    # New-style records enabled the flags and re-queried; legacy records only
+    # queried the flags at rest and cannot distinguish depth of support.
+    is_measured = "supported_flags" in kitty_kb
+    if not is_measured:
+        print("Flags were queried at rest only (legacy probe); flag support was "
+              "not actively measured.")
+        print()
+
     flags = [
         ("disambiguate", "Disambiguate escape codes"),
         ("report_events", "Report event types"),
@@ -3356,26 +3382,42 @@ def show_kitty_keyboard_results(sw_name, entry):
             "#": idx,
             "Flag": description,
             "Key": f"``{key}``",
-            "State": "Yes" if value else "No",
+            "Supported" if is_measured else "State": "Yes" if value else "No",
         })
 
     table_str = tabulate.tabulate(tabulated_flags, headers="keys", tablefmt="rst")
     print_datatable(table_str)
 
-    if not any(kitty_kb.values()):
-        # known bug for alacritty (fix rejected),
-        # also detected in microsoft terminal.exe (not investigated)
+    if is_measured:
+        def fmt_tristate(value):
+            return "n/a" if value is None else "Yes" if value else "No"
+
+        print(f"- Flag stack (``CSI > flags u`` push / ``CSI < u`` pop): "
+              f"{fmt_tristate(kitty_kb.get('flag_stack'))}")
+        print(f"- Set mode (``CSI = flags ; 1 u``): "
+              f"{fmt_tristate(kitty_kb.get('set_mode'))}")
+        print(f"- Flags enabled before probe: {kitty_kb.get('initial_flags', 0)}")
+        print()
+
+    if is_measured and not kitty_kb.get("supported_flags"):
         print()
         print(".. note::")
         print()
         print("   Although this terminal responds to the ``CSI ? u`` query")
-        print("   (proving it supports the protocol), **all individual flags are")
-        print("   reported as disabled**.  This likely indicates a terminal bug.")
+        print("   (proving it recognizes the protocol), **it did not honor any")
+        print("   flags when they were enabled**.  This likely indicates a")
+        print("   terminal bug or a query-only stub.")
         print()
 
-    print("Detection is performed by sending ``CSI ? u`` to query the current")
-    print("progressive enhancement flags. A terminal that supports this protocol")
-    print("responds with the active flags value.")
+    if is_measured:
+        print("Detection is performed by enabling all progressive enhancement")
+        print("flags -- by push (``CSI > 31 u``) and by set (``CSI = 31 ; 1 u``) --")
+        print("and re-querying with ``CSI ? u`` to measure which flags the terminal")
+        print("honors, before restoring its original flags.")
+    else:
+        print("Detection was performed by sending ``CSI ? u`` to query the current")
+        print("progressive enhancement flags. A terminal that supports this protocol")
+        print("responds with the active flags value.")
     print()
     print('.. _`Kitty keyboard protocol`: '
           'https://sw.kovidgoyal.net/kitty/keyboard-protocol/')

--- a/ucs_detect/__init__.py
+++ b/ucs_detect/__init__.py
@@ -602,8 +602,14 @@ def _build_features_kv_pairs(term, results):
             else:
                 pairs.append((mode_label, term.yellow("N/A")))
 
-    if results.get('kitty_keyboard') is not None:
-        pairs.append(("Kitty Keyboard?", _color_yes_no(term, True)))
+    kitty_kb = results.get('kitty_keyboard')
+    if kitty_kb is not None:
+        flag_keys = ('disambiguate', 'report_events', 'report_alternates',
+                     'report_all_keys', 'report_text')
+        n_flags = sum(bool(kitty_kb.get(key)) for key in flag_keys)
+        suffix = f" ({n_flags}/{len(flag_keys)} flags"
+        suffix += " + stack)" if kitty_kb.get('flag_stack') else ")"
+        pairs.append(("Kitty Keyboard?", _color_yes_no(term, True, suffix)))
     else:
         pairs.append(("Kitty Keyboard?", _color_yes_no(term, False)))
 

--- a/ucs_detect/terminal.py
+++ b/ucs_detect/terminal.py
@@ -13,6 +13,7 @@ import contextlib
 
 # 3rd party
 import blessed
+from blessed.keyboard import KittyKeyboardProtocol
 
 SCREEN_RATIOS = [(4, 3), (16, 9), (16, 10), (21, 9), (32, 9)]
 
@@ -360,19 +361,64 @@ def maybe_determine_colors(term, writer, timeout=1.0):
     return result
 
 
+#: All five Kitty keyboard protocol progressive enhancement flags
+KITTY_KB_ALL_FLAGS = 31
+
+
 def maybe_determine_kitty_keyboard(term, timeout=1.0):
-    """Query Kitty keyboard protocol support."""
-    result = {}
-    kb_state = term.get_kitty_keyboard_state(timeout=timeout)
-    if kb_state is not None:
-        result['kitty_keyboard'] = {
-            'disambiguate': kb_state.disambiguate,
-            'report_events': kb_state.report_events,
-            'report_alternates': kb_state.report_alternates,
-            'report_all_keys': kb_state.report_all_keys,
-            'report_text': kb_state.report_text,
+    """
+    Measure Kitty keyboard protocol support by enabling flags and querying them back.
+
+    A terminal at rest always reports flags=0 to the bare ``CSI ? u`` query, so the current
+    flags alone cannot distinguish depth of support.  Instead, request all five progressive
+    enhancement flags -- by push (``CSI > 31 u``) and by set (``CSI = 31 ; 1 u``) -- and
+    re-query after each: per the protocol specification, terminals enable the flags they
+    support and ignore the rest.
+
+    The per-flag booleans report whether each flag was honored, ``flag_stack`` and
+    ``set_mode`` report whether the push/pop stack and the set escape worked (``None`` when
+    indeterminate because no flags are supported), and the terminal's original flags are
+    always restored on exit.
+    """
+    kb_initial = term.get_kitty_keyboard_state(timeout=timeout)
+    if kb_initial is None:
+        return {}
+
+    def query_value():
+        state = term.get_kitty_keyboard_state(timeout=timeout)
+        return state.value if state is not None else 0
+
+    try:
+        # Push all flags onto the stack, then pop; terminal should return to initial flags
+        echo(term, f'\x1b[>{KITTY_KB_ALL_FLAGS}u')
+        pushed = query_value()
+        echo(term, '\x1b[<u')
+        popped = query_value()
+
+        # Set all flags directly (mode 1 = set/clear exactly)
+        echo(term, f'\x1b[={KITTY_KB_ALL_FLAGS};1u')
+        set_value = query_value()
+    finally:
+        # Restore the terminal's original flags even if a mid-probe query timed out
+        echo(term, f'\x1b[={kb_initial.value};1u')
+
+    supported_flags = pushed | set_value
+    kb_supported = KittyKeyboardProtocol(supported_flags)
+    return {
+        'kitty_keyboard': {
+            'disambiguate': kb_supported.disambiguate,
+            'report_events': kb_supported.report_events,
+            'report_alternates': kb_supported.report_alternates,
+            'report_all_keys': kb_supported.report_all_keys,
+            'report_text': kb_supported.report_text,
+            'initial_flags': kb_initial.value,
+            'supported_flags': supported_flags,
+            'flag_stack': (pushed == supported_flags and popped == kb_initial.value
+                           if supported_flags else None),
+            'set_mode': (set_value == supported_flags
+                         if supported_flags else None),
         }
-    return result
+    }
 
 
 def echo(term, data):


### PR DESCRIPTION
Complete kitty keyboard probe. Even kitty only ranked 'partial' support on the old one. The old probe only queried the current state of the feature flags, which should always report 0 on a compliant implementation. The new probe enables all 5 feature flags, then checks which ones 'stick', restoring the terminal's original flags afterward. 'Full' support now means all five flags are honored and the push/pop flag stack works. 'Partial' means the terminal responds to the query but falls short of that - some flags unsupported, or a broken stack. 'None' means the terminal doesn't respond to the keyboard protocol query at all. Existing data files (probed at rest) still render as 'Partial' and are labeled as legacy measurements.